### PR TITLE
Add `@astrojs/prism` to overrides

### DIFF
--- a/tests/adapters.ts
+++ b/tests/adapters.ts
@@ -8,6 +8,7 @@ export async function test(options: RunOptions) {
 		overrides: {
 			'@astrojs/internal-helpers': true,
 			'@astrojs/markdown-remark': true,
+			'@astrojs/prism': true,
 			'@astrojs/telemetry': true,
 		},
 		branch: 'main',

--- a/tests/expressive-code.ts
+++ b/tests/expressive-code.ts
@@ -9,6 +9,7 @@ export async function test(options: RunOptions) {
 			'@astrojs/mdx': true,
 			'@astrojs/internal-helpers': true,
 			'@astrojs/markdown-remark': true,
+			'@astrojs/prism': true,
 			'@astrojs/telemetry': true,
 		},
 		branch: 'main',

--- a/tests/integration-kit.ts
+++ b/tests/integration-kit.ts
@@ -8,6 +8,7 @@ export async function test(options: RunOptions) {
 		overrides: {
 			'@astrojs/internal-helpers': true,
 			'@astrojs/markdown-remark': true,
+			'@astrojs/prism': true,
 			'@astrojs/vue': true,
 			'@astrojs/tailwind': true,
 			'@astrojs/preact': true,


### PR DESCRIPTION
Aims to fix test runs by including the Prism package in overrides. I think this most likely now necessary since the change in https://github.com/withastro/astro/pull/11250