### PR TITLE
Add Starlight to tests

### DIFF
--- a/tests/starlight.ts
+++ b/tests/starlight.ts
@@ -17,7 +17,8 @@ export async function test(options: RunOptions) {
 		branch: "main",
 		test: [
 			// Check types pass
-			"pnpm --filter starlight-docs astro sync && pnpm typecheck",
+			"pnpm --filter starlight-docs astro sync",
+			"pnpm typecheck",
 			// Run tests for core Starlight package
 			"pnpm --filter @astrojs/starlight test",
 			// Smoke test that building example projects works

--- a/tests/starlight.ts
+++ b/tests/starlight.ts
@@ -1,0 +1,27 @@
+import type { RunOptions } from "../types.d.ts";
+import { runInRepo } from "../utils.ts";
+
+export async function test(options: RunOptions) {
+	await runInRepo({
+		...options,
+		repo: "withastro/starlight",
+		overrides: {
+			"@astrojs/internal-helpers": true,
+			"@astrojs/markdown-remark": true,
+			"@astrojs/mdx": true,
+			"@astrojs/prism": true,
+			"@astrojs/sitemap": true,
+			"@astrojs/tailwind": true,
+			"@astrojs/telemetry": true,
+		},
+		branch: "main",
+		test: [
+			// Check types pass
+			"pnpm --filter starlight-docs astro sync && pnpm typecheck",
+			// Run tests for core Starlight package
+			"pnpm --filter @astrojs/starlight test",
+			// Smoke test that building example projects works
+			"pnpm build:examples",
+		],
+	});
+}


### PR DESCRIPTION
This PR adds configuration to run Starlight’s tests as part of the ecosystem CI. (N.B. this currently fails due to https://github.com/withastro/starlight/issues/2271 — part of the motivation for this PR was that we probably could have caught that issue earlier.)

One question: do we need `"astro": true` in the `overrides` option? Or is that always implicitly the case? I noticed no other test suites used it.— **Edit:** tests “successfully failed” without an explicit override, so I’m guessing that one is automatic.